### PR TITLE
Use ng-src for images to avoid 404s

### DIFF
--- a/templates/single-apppage.html
+++ b/templates/single-apppage.html
@@ -8,7 +8,7 @@
 			<h2 ng-bind-html="siteData.title.rendered"></h2>
 			<p ng-if="content" ng-bind-html="content"></p>
 			<p ng-if="siteData.author_name" ng-bind-html="siteData.author_name"></p>
-			<img ng-if="siteData.media_details" src="{{siteData.media_details.sizes.medium.source_url}}" />
+			<img ng-if="siteData.media_details" ng-src="{{siteData.media_details.sizes.medium.source_url}}" />
 		</div>
 
 		<div class="item tabs tabs-secondary tabs-icon-left">

--- a/templates/single-comment.html
+++ b/templates/single-comment.html
@@ -8,7 +8,7 @@
 			<h2 ng-bind-html="siteData.title.rendered"></h2>
 			<p ng-if="content" ng-bind-html="content"></p>
 			<p ng-if="siteData.author_name" ng-bind-html="siteData.author_name"></p>
-			<img ng-if="siteData.media_details" src="{{siteData.media_details.sizes.medium.source_url}}" />
+			<img ng-if="siteData.media_details" ng-src="{{siteData.media_details.sizes.medium.source_url}}" />
 		</div>
 
 		<div class="item tabs tabs-secondary tabs-icon-left">

--- a/templates/single-post.html
+++ b/templates/single-post.html
@@ -8,7 +8,7 @@
 			<h2 ng-bind-html="siteData.title.rendered"></h2>
 			<p ng-if="content" ng-bind-html="content"></p>
 			<p ng-if="siteData.author_name" ng-bind-html="siteData.author_name"></p>
-			<img ng-if="siteData.media_details" src="{{siteData.media_details.sizes.medium.source_url}}" />
+			<img ng-if="siteData.media_details" ng-src="{{siteData.media_details.sizes.medium.source_url}}" />
 		</div>
 
 		<div class="item tabs tabs-secondary tabs-icon-left">

--- a/templates/site-section-details.html
+++ b/templates/site-section-details.html
@@ -8,7 +8,7 @@
 			<h2 ng-bind-html="siteData.title.rendered"></h2>
 			<p ng-if="content" ng-bind-html="content"></p>
 			<p ng-if="siteData.author_name" ng-bind-html="siteData.author_name"></p>
-			<img ng-if="siteData.media_details" src="{{siteData.media_details.sizes.medium.source_url}}" />
+			<img ng-if="siteData.media_details" ng-src="{{siteData.media_details.sizes.medium.source_url}}" />
 		</div>
 
 		<div class="item tabs tabs-secondary tabs-icon-left">


### PR DESCRIPTION
When you directly set an image's 'src' attribute to an Angular binding,
the browser will request that unresolved placeholder, causing a 404.

By using ng-src, we let Angular set the 'src' attribute when the value has
actually resolved.

https://docs.angularjs.org/api/ng/directive/ngSrc
